### PR TITLE
gi/metadata test Rinkeby. Use mintWithTokenURI to test openSea

### DIFF
--- a/contracts/Kame.sol
+++ b/contracts/Kame.sol
@@ -2,9 +2,10 @@ pragma solidity ^0.5.0;
 
 import "../node_modules/@openzeppelin/contracts/token/ERC721/ERC721Full.sol";
 import "../node_modules/@openzeppelin/contracts/token/ERC721/ERC721Mintable.sol";
+import "../node_modules/@openzeppelin/contracts/token/ERC721/ERC721MetadataMintable.sol";
 import "../node_modules/@openzeppelin/contracts/ownership/Ownable.sol";
 
-contract Kame is ERC721Full, ERC721Mintable, Ownable {
+contract Kame is ERC721Full, ERC721Mintable, Ownable, ERC721MetadataMintable {
   struct Kora {
     bytes32 metadata;
     address minter;
@@ -24,16 +25,16 @@ contract Kame is ERC721Full, ERC721Mintable, Ownable {
       mint(msg.sender, 0);
       kora.push(nullKora);
     }
-
-  function mintKora (bytes32 metadata) public returns(bool, uint256) {
+  function mintKora (uint256 potentialId, bytes32 metadata, string memory tokenURI) public returns(bool, uint256) {
+    uint256 newTokenId = totalSupply();
+    require(potentialId == newTokenId, "Kame: potentialId is offset incorrectly. Doesn't match new available ID.");
     address minter = msg.sender;
-    uint256 newTokenId = kora.length;
     Kora memory newKora = Kora({
       metadata: metadata,
       minter: minter,
       mainnetLock: false
     });
-    if (mint(minter, newTokenId) == true) {
+    if (mintWithTokenURI(minter, newTokenId, tokenURI) == true) {
       kora.push(newKora);
       hashToId[metadata] = newTokenId;
       return (true, newTokenId);
@@ -55,5 +56,6 @@ contract Kame is ERC721Full, ERC721Mintable, Ownable {
     } else return false;
   }
 
+  // function kill() public onlyOwner { selfdestruct(msg.sender); }
   function () external payable {}
 }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -48,13 +48,21 @@ module.exports = {
      port: 8545,            // Standard Ethereum port (default: none)
      network_id: "*",       // Any network (default: none)
     },
+    kameprod: {
+      provider: (() => {
+        return new HDWalletProvider(mnemonic, process.env.KAME_PROD_RPC)
+      }),
+      type: "quorum",
+      gasPrice: 0,
+      network_id: 1337 // Match any network id
+    },
     kamedev: {
       provider: (() => {
         return new HDWalletProvider(mnemonic, process.env.KAME_DEV_RPC)
       }),
       type: "quorum",
       gasPrice: 0,
-      network_id: '*' // Match any network id
+      network_id: 1337 // Match any network id
     },
 
     // Another network with more advanced options...
@@ -69,14 +77,22 @@ module.exports = {
 
     // Useful for deploying to a public network.
     // NB: It's important to wrap the provider as a function.
-    // ropsten: {
-      // provider: () => new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/YOUR-PROJECT-ID`),
-      // network_id: 3,       // Ropsten's id
-      // gas: 5500000,        // Ropsten has a lower block limit than mainnet
-      // confirmations: 2,    // # of confs to wait between deployments. (default: 0)
-      // timeoutBlocks: 200,  // # of blocks before a deployment times out  (minimum/default: 50)
-      // skipDryRun: true     // Skip dry run before migrations? (default: false for public nets )
-    // },
+    rinkeby: {
+      provider: () => new HDWalletProvider(mnemonic, `https://rinkeby.infura.io/v3/${process.env.INFURA_KEY}`),
+      network_id: 4,       // Rinkeby's id
+      gas: 5500000,        // Rinkeby has a lower block limit than mainnet
+      confirmations: 2,    // # of confs to wait between deployments. (default: 0)
+      timeoutBlocks: 200,  // # of blocks before a deployment times out  (minimum/default: 50)
+      skipDryRun: true     // Skip dry run before migrations? (default: false for public nets )
+    },
+    ropsten: {
+      provider: () => new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/${process.env.INFURA_KEY}`),
+      network_id: 3,       // Ropsten's id
+      gas: 5500000,        // Ropsten has a lower block limit than mainnet
+      confirmations: 2,    // # of confs to wait between deployments. (default: 0)
+      timeoutBlocks: 200,  // # of blocks before a deployment times out  (minimum/default: 50)
+      skipDryRun: true     // Skip dry run before migrations? (default: false for public nets )
+    },
 
     // Useful for private networks
     // private: {


### PR DESCRIPTION
Add Rinkeby and metadata dependencies, successfully tested on Opensea.

Minter checks a potential new contract ID for token, and its required to be correct in order to mint.